### PR TITLE
Fix typo in UniswapV2ExchangeAdapter.sol

### DIFF
--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
@@ -29,7 +29,7 @@ contract UniswapV2ExchangeAdapter {
     **/
 
     /*
-    * Write a state varable to store the address of the Uniswap Exchange V2 Router Contract
+    * Write a state variable to store the address of the Uniswap Exchange V2 Router Contract
     */
    
    


### PR DESCRIPTION
`Write a state varable` -> `Write a state variable`